### PR TITLE
API v3 using django-rest-framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,13 @@ Run the Makefile after changing any CoffeeScript or Less files.
 
 ## API
 
-To create an API key:
+The API is available at `/ldb/api/v3/`. Authentication is done using a valid session (for in-browser testing) or a token (send an `Authorization: Token <token>` header).
+
+To create an API token:
 
 1. Create a new user through the Django admin interface, please prefix username with `api_`
 2. Set password field to `!` in database (e.g. through phpPgAdmin)
-3. Assign new API key to new user in Django admin interface
-
+3. Assign new API token to new user in Django admin interface
 
 ## Update to Django 1.8
 

--- a/dienst2/middleware.py
+++ b/dienst2/middleware.py
@@ -24,8 +24,14 @@ class RequireLoginMiddleware(object):
             return
 
         # resolve() will raise an Http404 error if url not found
-        view_name = resolve(request.path_info).view_name
-        if view_name.startswith('api_'):
+        r = resolve(request.path_info)
+
+        # django-rest-framework (DEFAULT_PERMISSION_CLASSES in settings.py)
+        if r._func_path.startswith("rest_framework.") or r._func_path.startswith("ldb.views_api."):
+            return
+
+        # tastypie (we do this ourselves:
+        if r.view_name.startswith('api_'):
             auth = ApiKeyAuthentication()
             auth_result = auth.is_authenticated(request)
 
@@ -35,5 +41,6 @@ class RequireLoginMiddleware(object):
             if auth_result is not True:
                 return http.HttpUnauthorized()
 
+        # other pages except login page
         elif request.path != self.require_login_path:
             return redirect_to_login(request.path)

--- a/dienst2/settings.py
+++ b/dienst2/settings.py
@@ -99,6 +99,8 @@ INSTALLED_APPS = (
     'reversion',
     'haystack',
     'tastypie',
+    'rest_framework',
+    'rest_framework.authtoken',
     'django.contrib.admin',
     'django.contrib.admindocs',
     'dienst2',
@@ -132,6 +134,21 @@ AUTHENTICATION_BACKENDS = (
     'django_auth_ldap.backend.LDAPBackend',
     'django.contrib.auth.backends.ModelBackend',
 )
+
+REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': (
+        'rest_framework.authentication.TokenAuthentication',
+        'rest_framework.authentication.SessionAuthentication',
+    ),
+    'DEFAULT_PERMISSION_CLASSES': (
+        'rest_framework.permissions.IsAuthenticated',
+    ),
+    'DEFAULT_FILTER_BACKENDS': (
+        'rest_framework.filters.DjangoFilterBackend',
+    ),
+    'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
+    'PAGE_SIZE': 20,
+}
 
 # A sample logging configuration. The only tangible logging
 # performed by this configuration is to send an email to

--- a/ldb/models.py
+++ b/ldb/models.py
@@ -207,7 +207,8 @@ class Person(Entity):
         return ('ldb_people_detail', [str(self.id)])
 
     def __unicode__(self):
-        return u'%s, %s %s%s' % (self.surname, self.firstname, self.preposition, u' ✝' if self.deceased else '')
+        return (u'%s, %s %s%s' % \
+                (self.surname, self.firstname, self.preposition, u' ✝' if self.deceased else '')).strip()
 
 
 class Member(models.Model):
@@ -328,7 +329,7 @@ class CommitteeMembership(models.Model):
 
     # Django admin doesn't support nested inlines,
     # so we'll just link to Person instead.
-    person = models.ForeignKey(Person)
+    person = models.ForeignKey(Person, related_name="committees")
     committee = models.ForeignKey(Committee)
     board = models.IntegerField(_('board'))
     position = models.CharField(_('position'), max_length=50, blank=True)

--- a/ldb/serializers.py
+++ b/ldb/serializers.py
@@ -1,0 +1,48 @@
+from rest_framework import serializers
+from rest_framework.fields import IntegerField, ReadOnlyField
+
+from ldb.models import Person, Member, Student, Employee, Alumnus, CommitteeMembership, Organization
+
+
+class MemberSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Member
+        exclude = ('merit_history',)
+
+
+class StudentSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Student
+
+
+class AlumnusSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Alumnus
+
+
+class EmployeeSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Employee
+
+class CommitteeMembershipSerializer(serializers.ModelSerializer):
+    committee = serializers.StringRelatedField()
+
+    class Meta:
+        model = CommitteeMembership
+
+class PersonSerializer(serializers.HyperlinkedModelSerializer):
+    member = MemberSerializer()
+    student = StudentSerializer()
+    alumnus = AlumnusSerializer()
+    employee = EmployeeSerializer()
+    living_with = serializers.HyperlinkedRelatedField(view_name='person-detail', read_only=True)
+    committees = CommitteeMembershipSerializer(many=True, read_only=True)
+    age = ReadOnlyField()
+
+    class Meta:
+        model = Person
+        exclude = ('comment',)
+
+class OrganizationSerializer(serializers.HyperlinkedModelSerializer):
+    class Meta:
+        model = Organization

--- a/ldb/urls.py
+++ b/ldb/urls.py
@@ -1,9 +1,10 @@
 from django.conf.urls import patterns, include, url
+from rest_framework import routers
 from tastypie.api import Api
 
+from ldb import views_api
 from ldb.api import *
 from ldb.export import ExportResource
-
 
 api = Api(api_name='v2')
 
@@ -18,8 +19,15 @@ api.register(CommitteeMembershipResource())
 api.register(ModificationResource())
 api.register(ExportResource())
 
+router = routers.DefaultRouter()
+router.register(r'people', views_api.PersonViewSet)
+router.register(r'organizations', views_api.OrganizationsViewSet)
+
 urlpatterns = patterns('',
                        (r'^api/', include(api.urls)),
 
                        url(r'^$', 'ldb.views.index', name="ldb_index"),
+
+                       url(r'^api/v3/', include(router.urls)),
+                       # url(r'^api/v3/api-auth/', include('rest_framework.urls', namespace='rest_framework'))
 )

--- a/ldb/views_api.py
+++ b/ldb/views_api.py
@@ -1,0 +1,15 @@
+from rest_framework import viewsets
+
+from ldb.models import Person, Organization
+from ldb.serializers import PersonSerializer, OrganizationSerializer
+
+
+class PersonViewSet(viewsets.ReadOnlyModelViewSet):
+    serializer_class = PersonSerializer
+    queryset = Person.objects.all()
+    filter_fields = ('ldap_username', 'netid', 'student__student_number')
+
+
+class OrganizationsViewSet(viewsets.ReadOnlyModelViewSet):
+    queryset = Organization.objects.all()
+    serializer_class = OrganizationSerializer

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,6 @@ simplejson==3.6.5
 six==1.9.0
 wsgiref==0.1.2
 django_sendmail_backend
+djangorestframework==3.1.2
+django-filter==0.10.0
+markdown==2.6.2


### PR DESCRIPTION
django-rest-framework seems to be the way forward as decided by the Django community, so it would be unwise to invest more time in the current v2 Tastypie API.

For now, we keep the v2 API for backwards compatibility. When Userman2 is migrated to this v3 API, we can drop the Tastypie ApiKey authentication check in the `RequireLoginMiddleware`.

Fixes #48.