### PR TITLE
Add arrow navigation to search results. Fixes #81

### DIFF
--- a/ldb/templates/ldb/index.html
+++ b/ldb/templates/ldb/index.html
@@ -36,7 +36,6 @@
 
 
       $('#results').on("keyup", "a", function (e) {
-          console.log(e.keyCode);
         switch(e.keyCode) {
           case 38:
             if($(this).prev().hasClass("list-group-item")) {

--- a/ldb/templates/ldb/index.html
+++ b/ldb/templates/ldb/index.html
@@ -29,7 +29,7 @@
             $('#results').html('&nbsp;');
         }
         else
-          if(e.key === "ArrowDown") {
+          if(e.keyCode === 40) {
             $('#results a:first-child').focus();
           }
       });

--- a/ldb/templates/ldb/index.html
+++ b/ldb/templates/ldb/index.html
@@ -10,7 +10,7 @@
       $('#spinner').hide();
       var $q = $('#q');
 
-      $q.keyup(function () {
+      $q.keyup(function (e) {
         if (q != $q.val()) {
           q = $('#q').val();
           location.hash = q;
@@ -27,6 +27,33 @@
           }
           else
             $('#results').html('&nbsp;');
+        }
+        else
+          if(e.key === "ArrowDown") {
+            $('#results a:first-child').focus();
+          }
+      });
+
+
+      $('#results').on("keyup", "a", function (e) {
+        switch(e.key) {
+          case "ArrowUp":
+            $(this).prev().focus();
+            break;
+          case "ArrowDown":
+            $(this).next().focus();
+            break;
+          case "ArrowLeft":
+            $(this).prev().focus();
+            break;
+          case "ArrowRight":
+            $(this).next().focus();
+            break;
+          case "Escape":
+            $q.focus();
+            break;
+          default:
+            // nop
         }
       });
 

--- a/ldb/templates/ldb/index.html
+++ b/ldb/templates/ldb/index.html
@@ -36,20 +36,20 @@
 
 
       $('#results').on("keyup", "a", function (e) {
-        switch(e.key) {
-          case "ArrowUp":
-            $(this).prev().focus();
+          console.log(e.keyCode);
+        switch(e.keyCode) {
+          case 38:
+            if($(this).prev().hasClass("list-group-item")) {
+              $(this).prev().focus();
+            }
+            else {
+              $q.focus();
+            }
             break;
-          case "ArrowDown":
+          case 40:
             $(this).next().focus();
             break;
-          case "ArrowLeft":
-            $(this).prev().focus();
-            break;
-          case "ArrowRight":
-            $(this).next().focus();
-            break;
-          case "Escape":
+          case 13:
             $q.focus();
             break;
           default:


### PR DESCRIPTION
- [x] From searchbar, arrow down sets you to first result
- [x] In the results, up/down arrows move focus up and down
- [x] With a result selected, hit `esc` to focus the search bar again