### PR TITLE
Update to Django 2.2.12 and Python 3.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ lib
 /dienst2/whoosh_index/
 node_modules
 venv/
+env/
+.vscode/

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /src
 COPY . .
 RUN yarn install --flat
 
-FROM python:3.7
+FROM python:3.8
 
 # CH CA certificate for PostgreSQL TLS connections
 ADD https://ch.tudelft.nl/certs/wisvch.crt /usr/local/share/ca-certificates/wisvch.crt

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,4 +1,4 @@
-FROM python:3.7-stretch
+FROM python:3.8
 
 WORKDIR /srv
 ENTRYPOINT ["/srv/docker-entrypoint-dev.sh"]
@@ -6,7 +6,7 @@ CMD ["dev"]
 EXPOSE 8000
 
 RUN export DEBIAN_FRONTEND="noninteractive" && \
-    curl -sL https://deb.nodesource.com/setup_10.x | bash - && \
+    curl -sL https://deb.nodesource.com/setup_14.x | bash - && \
     curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
     echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list && \
     apt-get update && \

--- a/ldb/admin.py
+++ b/ldb/admin.py
@@ -2,16 +2,15 @@ from __future__ import unicode_literals
 
 import datetime
 
-from django.contrib import admin
 from django import forms
+from django.contrib import admin
 from django.db.models import Q
 from django.utils.encoding import force_text
-
-from ldb.ImportExportVersionModelAdmin import ImportExportVersionModelAdmin
-from import_export import fields, resources, widgets
 from django.utils.translation import ugettext_lazy as _
+from import_export import resources, widgets
 from reversion_compare.admin import CompareVersionAdmin
 
+from ldb.ImportExportVersionModelAdmin import ImportExportVersionModelAdmin
 from ldb.models import *
 
 
@@ -139,7 +138,7 @@ class PersonResource(resources.ModelResource):
             obj.student.full_clean(exclude='person')
         except ValidationError as e:
             for key, value in e:
-                if key is not 'person':
+                if key != 'person':
                     errors["student__" + key] = ValidationError(force_text(value), code="invalid")
 
         # Member validation
@@ -150,7 +149,7 @@ class PersonResource(resources.ModelResource):
             obj.member.full_clean(exclude='person')
         except ValidationError as e:
             for key, value in e:
-                if key is not 'person':
+                if key != 'person':
                     errors["member__" + key] = ValidationError(force_text(value), code="invalid")
 
         if errors:

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ django-health-check==3.8.0
 django-import-export==1.2.0
 django-reversion-compare==0.8.6
 django-reversion==3.0.2
-Django==2.2.10
+Django==2.2.12
 djangorestframework==3.9.1
 drf-writable-nested==0.5.1
 elasticsearch>=2.0.0,<3.0.0 # rq.filter: >=2.0.0,<3.0.0
@@ -24,7 +24,7 @@ python-dateutil==2.7.5
 python-memcached==1.59
 python-mimeparse==1.6.0
 pytz
-requests==2.21.0
+requests==2.23.0
 setproctitle
 simplejson==3.16.0
 six==1.12.0


### PR DESCRIPTION
Django 2.2.8+ is compatible with Python 3.8:
https://docs.djangoproject.com/en/2.2/faq/install/#what-python-version-can-i-use-with-django

Also update requests to fix "RequestsDependencyWarning" during build.

Replace "is not" by "!=" to fix SyntaxWarning.

Update `Dockerfile-dev` to match versions in `Dockerfile`.