### PR TITLE
Add docker/setup-buildx-action to fix error for deployment.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,6 +57,8 @@ jobs:
           type=ref, event=pr
           type=semver,pattern={{version}}
           type=sha
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
     - name: Login to Quay
       uses: docker/login-action@v1
       with: 


### PR DESCRIPTION
Forgot to add this action, which is needed for the build-push-action@v2 to work, since it now uses Docker Buildx