### PR TITLE
Update CodeQL Analysis GitHub Workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,6 +2,7 @@ name: "Code scanning"
 on:
   push:
   pull_request:
+  workflow_dispatch:
   schedule:
     - cron: '0 11 * * 2'
 jobs:
@@ -10,14 +11,6 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
-      with:
-        # We must fetch at least the immediate parents so that if this is
-        # a pull request then we can checkout the head.
-        fetch-depth: 2
-    # If this run was triggered by a pull request event, then checkout
-    # the head of the pull request instead of the merge commit.
-    - run: git checkout HEAD^2
-      if: ${{ github.event_name == 'pull_request' }}
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v1
     - name: Autobuild


### PR DESCRIPTION
Should fix this error:
> 1 issue was detected with this workflow: git checkout HEAD^2 is no
> longer necessary. Please remove this step as Code Scanning recommends
> analyzing the merge commit for best results.