### PR TITLE
Disable CodeQL scanning on push

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,6 +1,5 @@
 name: "Code scanning"
 on:
-  push:
   pull_request:
   workflow_dispatch:
   schedule:


### PR DESCRIPTION
Dependabot PR workflows fail due to this.

https://docs.github.com/en/code-security/secure-coding/configuring-code-scanning#scanning-on-push